### PR TITLE
Ligue admin cmd

### DIFF
--- a/Personnel/src/commandLine/EmployeConsole.java
+++ b/Personnel/src/commandLine/EmployeConsole.java
@@ -18,11 +18,23 @@ public class EmployeConsole
 	{
 		return (employe) -> editerEmploye(employe);		
 	}
+	ListOption<Employe> gestionEmploye(){
+		return (employe) -> gestionEmploye(employe);
+	}
 
+	
+	Option gestionEmploye(Employe employe) {
+		Menu menu = new Menu("Selectionner le compte " + employe.getNom(), "g");
+		menu.add(afficher(employe));
+		menu.add(supprimerEmploye(employe));
+		menu.add(editerEmploye(employe));
+		menu.addBack("q");
+		menu.setAutoBack(true);
+		return menu;
+	}
 	Option editerEmploye(Employe employe)
 	{
-			Menu menu = new Menu("Gérer le compte " + employe.getNom(), "c");
-			menu.add(afficher(employe));
+			Menu menu = new Menu("Modifier le compte " + employe.getNom(), "c");
 			menu.add(changerNom(employe));
 			menu.add(changerPrenom(employe));
 			menu.add(changerMail(employe));
@@ -31,11 +43,10 @@ public class EmployeConsole
 			return menu;
 	}
 
+
 	private Option changerNom(final Employe employe)
 	{
-		return new Option("Changer le nom", "n", 
-				() -> {employe.setNom(getString("Nouveau nom : "));}
-			);
+		return new Option("Changer le nom", "n", () -> {employe.setNom(getString("Nouveau nom : "));});
 	}
 	
 	private Option changerPrenom(final Employe employe)
@@ -52,6 +63,15 @@ public class EmployeConsole
 	{
 		return new Option("Changer le password", "x", () -> {employe.setPassword(getString("Nouveau password : "));});
 	}
-	
+	private Option supprimerEmploye(final Employe employe) {
+		return new Option ("Supprimer l'employé","s", () -> 
+		{
+		  System.out.println("L'employé a été supprimer appuyer sur q pour revenir à l'écran précédent");
+		  employe.remove();
+		  
+		  
+		});
+	}
+
 
 }

--- a/Personnel/src/commandLine/LigueConsole.java
+++ b/Personnel/src/commandLine/LigueConsole.java
@@ -104,41 +104,32 @@ public class LigueConsole
 				}
 		);
 	}
-
 	
 	private Menu gererEmployes(Ligue ligue)
 	{
 		Menu menu = new Menu("Gérer les employés de " + ligue.getNom(), "e");
 		menu.add(afficherEmployes(ligue));
 		menu.add(ajouterEmploye(ligue));
-		menu.add(modifierEmploye(ligue));
-		menu.add(supprimerEmploye(ligue));
+		menu.add(selectionEmploye(ligue));
 		menu.addBack("q");
 		return menu;
 	}
 
-	private List<Employe> supprimerEmploye(final Ligue ligue)
-	{
-		return new List<>("Supprimer un employé", "s", 
-				() -> new ArrayList<>(ligue.getEmployes()),
-				(index, element) -> {element.remove();}
-				);
-	}
+
 	
 	private List<Employe> changerAdministrateur(final Ligue ligue)
 	{
-
-		return new  List<Employe> ("Modifier l'administrateur","a",
-		() -> new ArrayList<>(ligue.getEmployes()),
-		(index,element) -> {ligue.setAdministrateur(element);}
-		);
+		return new List<>("Changer l'aministrateur ", "a", 
+				() -> new ArrayList<>(ligue.getEmployes()),
+				(index, element) -> {ligue.setAdministrateur(element);}
+				);
 	}		
 
-	private List<Employe> modifierEmploye(final Ligue ligue)
+	private List<Employe> selectionEmploye(final Ligue ligue)
 	{
-		return new List<>("Modifier un employé", "e", 
+		return new List<>("Selectionner un employé","p",
 				() -> new ArrayList<>(ligue.getEmployes()),
-				employeConsole.editerEmploye()
+				employeConsole.gestionEmploye()
 				);
 	}
 	

--- a/Personnel/src/commandLine/LigueConsole.java
+++ b/Personnel/src/commandLine/LigueConsole.java
@@ -72,7 +72,7 @@ public class LigueConsole
 		Menu menu = new Menu("Editer " + ligue.getNom());
 		menu.add(afficher(ligue));
 		menu.add(gererEmployes(ligue));
-		//menu.add(changerAdministrateur(ligue));
+		menu.add(changerAdministrateur(ligue));
 		menu.add(changerNom(ligue));
 		menu.add(supprimer(ligue));
 		menu.addBack("q");
@@ -104,6 +104,7 @@ public class LigueConsole
 				}
 		);
 	}
+
 	
 	private Menu gererEmployes(Ligue ligue)
 	{
@@ -126,7 +127,11 @@ public class LigueConsole
 	
 	private List<Employe> changerAdministrateur(final Ligue ligue)
 	{
-		return null;
+
+		return new  List<Employe> ("Modifier l'administrateur","a",
+		() -> new ArrayList<>(ligue.getEmployes()),
+		(index,element) -> {ligue.setAdministrateur(element);}
+		);
 	}		
 
 	private List<Employe> modifierEmploye(final Ligue ligue)


### PR DESCRIPTION
Ajout :
Possibilité de changer l’administrateur d’une ligue en ligne de commande.

Modif : Dans le dialogue en ligne de commande, un employé doit être selectionné avant que l’on puisse choisir de modifier ou de supprimer.